### PR TITLE
ケースインセンシティブ化

### DIFF
--- a/src/router/functions.rs
+++ b/src/router/functions.rs
@@ -9,9 +9,9 @@ pub enum Command {
 // コマンドがあればそれを↑のEnum形式で、なければNoneを返す
 pub fn parse_command(plain_text: &str) -> Option<Command> {
     use Command::*;
-    let mut terms = plain_text.split_whitespace();
+    let mut terms = plain_text.to_lowercase().split_whitespace();     //ケースインセンシティブ化　全て小文字に直してから処理しています
     match terms.next() {
-        Some("@BOT_xecua_odai") => {
+        Some("@bot_xecua_odai") => {
             let command = terms.next();
             if command == None {
                 return None;


### PR DESCRIPTION
コマンドが大文字小文字の区別しないといけないものが存在しないので、あらかじめ大文字か小文字のどちらかに処理して揃えるといい感じになると思います。

なので、コマンドの内容をすべて小文字化した暁にはソースコード内の`eq_ignore_ascii_case`が必要なくなると思います